### PR TITLE
method get_aws_options always returns region set to us-east-1

### DIFF
--- a/lib/zabbix-cloudwatch.rb
+++ b/lib/zabbix-cloudwatch.rb
@@ -27,7 +27,7 @@ module ZabbixCloudwatch
     def get_aws_options
       raise AwsAccessKeyMissingException unless options.key?"aws-access-key"
       raise AwsSecretKeyMissingException unless options.key?"aws-secret-key"
-      if options.key?"aws-region" && options['aws-region'] != ''
+      if options.key?("aws-region") && options['aws-region'] != ''
         region = options["aws-region"]
       else
         region = 'us-east-1'


### PR DESCRIPTION
Lack of parentheses in " if options.key?"aws-region" && options['aws-region'] != '' " caused it to always fall through to the else and set region to use-east-1.  Pull request adds parens.  Tested failure and success on 1.8.7 and 2.0.