### PR TITLE
Add IAM Role support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: .
   specs:
-    zabbix-cloudwatch (0.2.0)
+    zabbix-cloudwatch (0.2.1)
       aws-sdk (~> 2)
       getopt (~> 1.4.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (2.2.14)
-      aws-sdk-resources (= 2.2.14)
-    aws-sdk-core (2.2.14)
+    aws-sdk (2.3.0)
+      aws-sdk-resources (= 2.3.0)
+    aws-sdk-core (2.3.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.14)
-      aws-sdk-core (= 2.2.14)
+    aws-sdk-resources (2.3.0)
+      aws-sdk-core (= 2.3.0)
     coveralls (0.8.10)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -28,8 +28,10 @@ GEM
     getopt (1.4.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    jmespath (1.1.3)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     json (1.8.3)
+    json_pure (1.8.3)
     mime-types (1.25.1)
     netrc (0.11.0)
     rake (10.5.0)
@@ -74,4 +76,4 @@ DEPENDENCIES
   zabbix-cloudwatch!
 
 BUNDLED WITH
-   1.10.2
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage: zabbix-cloudwatch
   --aws-access-key        AWS Access Key
   --aws-secret-key        AWS Secret Key
   --aws-region            AWS Region                                Default: us-east-1
+  --role-arn              ARN of IAM role to assume
 ```
 
 ## Getting it running
@@ -63,19 +64,23 @@ The following actions need to be allowed in IAM for this script to work with the
 
 ## AWS Credentials
 
-There are (3) ways to get your AWS Credentials into `zabbix-cloudwatch`.
+There are (4) ways to get your AWS Credentials into `zabbix-cloudwatch`.
 
-**Note that *none* of these options are "safe", so make sure you are using a set of IAM Keys with extremely restricted 
-permissions.**
+**Note that only the first of these options is "safe", so make sure you are using a set of IAM Keys with extremely restricted permissions.**
 
-### 1. Environment Variables (which is difficult with Zabbix):
+
+### 1. Use an IAM Role for your Zabbix server
+When your Zabbix server is started, assign a role to it and allow this role to perofm the required Cloud Watch interactions. The credentials are provided dynamically to the server by AWS.
+
+
+### 2. Environment Variables (which is difficult with Zabbix):
 ```bash
 export AWS_ACCESS_KEY_ID="YOUR ACCESS KEY" 
 export AWS_SECRET_ACCESS_KEY="YOUR SECRET ACCESS KEY"
 export AWS_REGION="YOUR AWS REGION"
 ```
 
-### 2. Within the binary in the gem.  
+### 3. Within the binary in the gem.  
 
 If you intend to do it this way, I suggest you make a copy of the binary
 and place it in your zabbix externalscript path (instead of the suggested symlink in the installation example).
@@ -96,7 +101,7 @@ chown zabbix:zabbix /var/lib/zabbixsrv/externalscripts/zabbix-cloudwatch
 
 The class variables for this are at the very top of the file for your convenience.
 
-### 3. Passing in your AWS Keys when you run zabbix-cloudwatch using the command line flags.
+### 4. Passing in your AWS Keys when you run zabbix-cloudwatch using the command line flags.
 
 ```bash
 zabbix-cloudwatch -n AWS/AutoScaling \
@@ -111,7 +116,7 @@ zabbix-cloudwatch -n AWS/AutoScaling \
 
 The order of preference that this gem uses for the region and keys (individually) are:
 
+* IAM Role
 * Commandline flag
 * Within the binary
 * Environment Variable
-

--- a/bin/zabbix-cloudwatch
+++ b/bin/zabbix-cloudwatch
@@ -24,6 +24,7 @@ opts = Getopt::Long.getopts(
    ["--aws-access-key", Getopt::REQUIRED],
    ["--aws-secret-key", Getopt::REQUIRED],
    ["--aws-region", Getopt::REQUIRED],
+   ["--role-arn", Getopt::REQUIRED],
    ["--version"]
 )
 
@@ -42,6 +43,7 @@ Usage: #{$0}
   --aws-access-key        AWS Access Key
   --aws-secret-key        AWS Secret Key
   --aws-region            AWS Region                                Default: us-east-1
+  --role-arn              Pass in a IAM Role ARN to assume that role
 
 EOF
   exit 1
@@ -57,11 +59,12 @@ if opts.key?"version"
   exit 0
 end
 
+
 unless opts.key?"aws-access-key"
-  opts["aws-access-key"] = (aws_access_key == '' && ENV["AWS_ACCESS_KEY_ID"])     || aws_access_key
+  opts["aws-access-key"] = ENV["AWS_ACCESS_KEY_ID"] if ENV["AWS_ACCESS_KEY_ID"]
 end
 unless opts.key?"aws-secret-key"
-  opts["aws-secret-key"] = (aws_secret_key == '' && ENV["AWS_SECRET_ACCESS_KEY"]) || aws_secret_key
+  opts["aws-secret-key"] = ENV["AWS_SECRET_ACCESS_KEY"] if ENV["AWS_SECRET_ACCESS_KEY"]
 end
 unless opts.key?"aws-region"
   opts["aws-region"] =     (aws_region     == '' && ENV["AWS_REGION"])            || aws_region

--- a/lib/zabbix-cloudwatch/version.rb
+++ b/lib/zabbix-cloudwatch/version.rb
@@ -1,4 +1,4 @@
 
 module ZabbixCloudwatch
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/zabbix-cloudwatch/zabbix-cloudwatch_spec.rb
+++ b/spec/zabbix-cloudwatch/zabbix-cloudwatch_spec.rb
@@ -35,7 +35,7 @@ module ZabbixCloudwatch
         lambda {ZabbixCloudwatch::GetCloudwatchMetric.new(options)}.should raise_error GetCloudwatchMetric::DimensionArgumentMissingException
       end
       it "Raises Exception when aws keys are not in options" do
-        options = {"namespace" => '', "metricname" => '', "dimension-value" => '', "dimension-name" => ''}
+        options = {"namespace" => '', "metricname" => '', "dimension-value" => '', "dimension-name" => '', "aws-secret-key" => ''}
         lambda {ZabbixCloudwatch::GetCloudwatchMetric.new(options)}.should raise_error GetCloudwatchMetric::AwsAccessKeyMissingException
         options = {"namespace" => '', "metricname" => '', "dimension-value" => '', "dimension-name" => '', "aws-access-key" => ''}
         lambda {ZabbixCloudwatch::GetCloudwatchMetric.new(options)}.should raise_error GetCloudwatchMetric::AwsSecretKeyMissingException


### PR DESCRIPTION
Hi Randy, I would like to be able to use this gem to get stats into Zabbix, however I need to be able to use IAM roles and assume roles (for cross account access). This fixes the biggest problem of having to provide credentials to the gem or in the environment somehow, as AWS will provide them as part of the IAM role. This PR includes:

Include Role Assumption
Fix tests to support IAM role

I would also be happy to take on maintenance of this gem.

Opened Issue: https://github.com/randywallace/zabbix-cloudwatch/issues/12
